### PR TITLE
sharing: Publish module settings to viewers, not just screen settings

### DIFF
--- a/server/sharing/view.coffee
+++ b/server/sharing/view.coffee
@@ -19,7 +19,7 @@ Meteor.smartPublish '/sharing/access', (_id, token) ->
       check token, String
       unless token is share.token
         throw new Meteor.Error 'invalid-token', 'The link you are using has expired.'
-    
+
     else
       throw new Meteor.Error 'invalid-sharing', 'The content you are trying to view is misconfigured.'
 
@@ -34,13 +34,21 @@ Meteor.smartPublish '/sharing/access', (_id, token) ->
   @addDependency 'screens', 'view', (screen) ->
     Views.find screen.view
 
+  @addDependency 'views', 'module', (view) ->
+    Modules.find _id: view.module
+
   @addDependency 'screens', '_id', (screen) -> [
     Settings.find context: type: 'screen', id: screen._id
     Data.find context: type: 'screen', id: screen._id
   ]
 
+  @addDependency 'modules', '_id', (module) -> [
+    Settings.find context: type: 'module', id: module._id
+    Data.find context: type: 'module', id: module._id
+  ]
+
   Shares.find {_id},
-    fields: 
+    fields:
       owner: 1
       title: 1
       entries: 1


### PR DESCRIPTION
Certain views depend on module settings at render time. This hasn't been much of a problem before because most views only use module settings at fetch time, if at all.

This does mean some more mongo queries when loading a share, but sharing is pretty low volume so I don't expect any issues from it.